### PR TITLE
Change router

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "react-hot-loader": "next",
     "react-redux": "^5.0.4",
     "redux": "^3.6.0",
-    "redux-little-router": "^13.1.2",
     "redux-thunk": "^2.2.0",
     "remote-redux-devtools": "^0.5.11",
     "sass-loader": "^6.0.5",

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -1,2 +1,3 @@
 export * from './items';
 export * from './status';
+export * from './router';

--- a/src/actions/router.js
+++ b/src/actions/router.js
@@ -1,0 +1,3 @@
+export function push (route) {
+    return { type: 'PUSH', route };
+}

--- a/src/app.js
+++ b/src/app.js
@@ -2,34 +2,26 @@ import fs from 'fs';
 import React from 'react';
 import _ from 'lodash';
 import { Provider } from 'react-redux';
-import { createStore, applyMiddleware, compose } from 'redux';
+import { createStore, applyMiddleware } from 'redux';
 import thunk from 'redux-thunk';
-import { routerForBrowser, RouterProvider } from 'redux-little-router';
 import ReactDOM from 'react-dom';
-import Routes from './routes';
 import reducers from './reducers';
 import { get as getFromPersistedStore } from '../lib/store';
 import { doesStoreExist, readRawStore, encryptStore } from './utils';
-import routesConfig from './routes.config';
+import Routes from './routes';
 import './styles/main.scss';
-
-const routerConfig = routerForBrowser({ routes: routesConfig });
-const routerMiddleware = routerConfig.middleware;
-const routerEnhancer = routerConfig.enhancer;
 
 const store = createStore(
     reducers,
     getInitialState(),
-    compose(routerEnhancer, applyMiddleware(routerMiddleware, thunk))
+    applyMiddleware(thunk)
 );
 
 saveAndEncryptOnStoreChange(store);
 
 ReactDOM.render(
     <Provider store={ store }>
-        <RouterProvider store={ store }>
-            <Routes></Routes>
-        </RouterProvider>
+        <Routes></Routes>
     </Provider>,
     document.getElementById('root')
 );

--- a/src/components/Link/Link.js
+++ b/src/components/Link/Link.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import { push } from '../../actions';
+import _ from 'lodash';
+
+function Link ({ navigate, href, children, ...props }) {
+    return (
+        <a
+            { ...props }
+            href={ href }
+            onClick={ (e) => {
+                e.preventDefault();
+                navigate(href);
+            }}
+        >
+            { children }
+        </a>
+    );
+}
+
+function mapDispatchToProps (dispatch) {
+    return {
+        navigate: path => dispatch(push(path))
+    };
+}
+
+const ConnectedLink = connect(
+    () => ({}),
+    mapDispatchToProps
+)(Link);
+
+export default ConnectedLink;

--- a/src/components/Link/index.js
+++ b/src/components/Link/index.js
@@ -1,0 +1,1 @@
+export { default } from './Link';

--- a/src/components/Route/Route.js
+++ b/src/components/Route/Route.js
@@ -1,0 +1,27 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import _ from 'lodash';
+
+function Route ({ path = '', activeRoute, children }) {
+    if (matchRoute(activeRoute, path)) {
+        return <div>{ children }</div>;
+    }
+
+    return null;
+}
+
+function mapStateToProps (state) {
+    return {
+        activeRoute: _.get(state, 'router.activeRoute', '/')
+    }
+}
+
+const ConnectedRoute = connect(
+    mapStateToProps
+)(Route);
+
+export default ConnectedRoute;
+
+function matchRoute (activeRoute, route) {
+    return activeRoute === route;
+}

--- a/src/components/Route/index.js
+++ b/src/components/Route/index.js
@@ -1,0 +1,1 @@
+export { default } from './Route';

--- a/src/pages/EntryPoint/EntryPoint.js
+++ b/src/pages/EntryPoint/EntryPoint.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { connect } from 'react-redux';
-import { push } from 'redux-little-router';
+import { push } from '../../actions';
 import './EntryPoint.scss';
 
 function EntryPoint ({ doesStoreExist, locked, redirect }) {

--- a/src/pages/Items/Items.js
+++ b/src/pages/Items/Items.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import _ from 'lodash';
-import { Link } from 'redux-little-router';
+import Link from '../../components/Link';
 import Item from '../../components/Item';
 import LockButton from '../../components/LockButton';
 import './Items.scss';

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -1,15 +1,12 @@
 import { combineReducers } from "redux";
-import { routerForBrowser } from 'redux-little-router';
 import status from "./statusReducer";
 import items from "./itemsReducer";
-import routesConfig from '../routes.config';
+import router from "./routerReducer";
 
-const routerConfig = routerForBrowser({ routes: routesConfig });
-const routerReducer = routerConfig.reducer;
 const rootReducer = combineReducers({
     status,
     items,
-    router: routerReducer
+    router
 });
 
 export default rootReducer;

--- a/src/reducers/routerReducer.js
+++ b/src/reducers/routerReducer.js
@@ -1,0 +1,16 @@
+const defaultState = {
+    activeRoute: '/'
+};
+
+export default function routerReducer (state = defaultState, action) {
+    switch (action.type) {
+        case 'PUSH':
+        return {
+            ...state,
+            activeRoute: action.route
+        };
+
+        default:
+        return state;
+    };
+}

--- a/src/routes.js
+++ b/src/routes.js
@@ -1,21 +1,25 @@
 import React from 'react';
-import { Switch, Route, Router } from 'react-router';
 import { createHashHistory } from 'history';
-import { Fragment } from 'redux-little-router';
 import ProtectedRoute from './components/ProtectedRoute';
 import Unlock from './pages/Unlock';
 import Init from './pages/Init';
 import EntryPoint from './pages/EntryPoint';
 import Items from './pages/Items';
 import NewEntry from './pages/NewEntry';
+import Route from './components/Route';
 
 const Routes = () => (
     <div>
-        <Fragment forRoute="/create-item"><NewEntry /></Fragment>
+        <Route path="/create-item"><NewEntry /></Route>
+        <Route path="/items"><Items /></Route>
+        <Route path="/unlock"><Unlock /></Route>
+        <Route path="/init"><Init /></Route>
+        <Route path="/"><EntryPoint /></Route>
+        {/*<Fragment forRoute="/create-item"><NewEntry /></Fragment>
         <Fragment forRoute="/items"><Items /></Fragment>
         <Fragment forRoute="/unlock"><Unlock /></Fragment>
         <Fragment forRoute="/init"><Init /></Fragment>
-        <Fragment forRoute="/"><EntryPoint /></Fragment>
+        <Fragment forRoute="/"><EntryPoint /></Fragment>*/}
     </div>
 )
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2148,7 +2148,7 @@ he@1.1.x:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/he/-/he-1.1.1.tgz#93410fd21b009735151f8868c2f271f3427e23fd"
 
-history@^4.5.1, history@^4.6.0, history@^4.6.1:
+history@^4.6.1:
   version "4.6.1"
   resolved "https://registry.yarnpkg.com/history/-/history-4.6.1.tgz#911cf8eb65728555a94f2b12780a0c531a14d2fd"
   dependencies:
@@ -2170,7 +2170,7 @@ hoek@2.x.x:
   version "2.16.3"
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-2.16.3.tgz#20bb7403d3cea398e91dc4710a8ff1b8274a25ed"
 
-hoist-non-react-statics@^1.0.3, hoist-non-react-statics@^1.2.0:
+hoist-non-react-statics@^1.0.3:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-1.2.0.tgz#aa448cf0986d55cc40773b17174b7dd066cb7cfb"
 
@@ -2347,7 +2347,7 @@ interpret@^1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.0.3.tgz#cbc35c62eeee73f19ab7b10a801511401afc0f90"
 
-invariant@^2.0.0, invariant@^2.2.0, invariant@^2.2.1, invariant@^2.2.2:
+invariant@^2.0.0, invariant@^2.2.0, invariant@^2.2.1:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.2.tgz#9e1f56ac0acdb6bf303306f338be3b204ae60360"
   dependencies:
@@ -3639,7 +3639,7 @@ path-to-regexp@0.1.7:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
 
-path-to-regexp@^1.5.3, path-to-regexp@^1.7.0:
+path-to-regexp@^1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.7.0.tgz#59fde0f435badacba103a84e9d3bc64e96b9937d"
   dependencies:
@@ -4004,7 +4004,7 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.0.0, prop-types@^15.5.4, prop-types@^15.5.7, prop-types@^15.5.8, prop-types@~15.5.7:
+prop-types@^15.0.0, prop-types@^15.5.4, prop-types@^15.5.7, prop-types@~15.5.7:
   version "15.5.10"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.10.tgz#2797dfc3126182e3a95e3dfbb2e893ddd7456154"
   dependencies:
@@ -4052,7 +4052,7 @@ qs@6.4.0, qs@~6.4.0:
   version "6.4.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.4.0.tgz#13e26d28ad6b0ffaa91312cd3bf708ed351e7233"
 
-query-string@^4.1.0, query-string@^4.3.2:
+query-string@^4.1.0:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/query-string/-/query-string-4.3.4.tgz#bbb693b9ca915c232515b228b1a02b609043dbeb"
   dependencies:
@@ -4140,27 +4140,6 @@ react-redux@^5.0.4:
     lodash-es "^4.2.0"
     loose-envify "^1.1.0"
     prop-types "^15.0.0"
-
-react-router-dom@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-4.1.1.tgz#3021ade1f2c160af97cf94e25594c5f294583025"
-  dependencies:
-    history "^4.5.1"
-    loose-envify "^1.3.1"
-    prop-types "^15.5.4"
-    react-router "^4.1.1"
-
-react-router@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/react-router/-/react-router-4.1.1.tgz#d448f3b7c1b429a6fbb03395099949c606b1fe95"
-  dependencies:
-    history "^4.6.0"
-    hoist-non-react-statics "^1.2.0"
-    invariant "^2.2.2"
-    loose-envify "^1.3.1"
-    path-to-regexp "^1.5.3"
-    prop-types "^15.5.4"
-    warning "^3.0.0"
 
 react@^15.5.4:
   version "15.5.4"
@@ -4275,16 +4254,6 @@ redux-devtools-instrument@^1.3.3:
   dependencies:
     lodash "^4.2.0"
     symbol-observable "^1.0.2"
-
-redux-little-router@^13.1.2:
-  version "13.1.2"
-  resolved "https://registry.yarnpkg.com/redux-little-router/-/redux-little-router-13.1.2.tgz#7ccdd4789949ba3d0a3305929e73501da96e37a0"
-  dependencies:
-    history "^4.6.1"
-    lodash.assign "^4.2.0"
-    prop-types "^15.5.8"
-    query-string "^4.3.2"
-    url-pattern "^1.0.3"
 
 redux-thunk@^2.2.0:
   version "2.2.0"
@@ -5150,10 +5119,6 @@ url-parse@^1.1.1:
   dependencies:
     querystringify "~1.0.0"
     requires-port "1.0.x"
-
-url-pattern@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/url-pattern/-/url-pattern-1.0.3.tgz#0409292471b24f23c50d65a47931793d2b5acfc1"
 
 url@^0.11.0:
   version "0.11.0"


### PR DESCRIPTION
It turns out that it is really unnecessary to use a routing library for an Electron app.
The routing between the top level components can be done in memory.